### PR TITLE
Replace boost::filesystem with std::filesystem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,9 +3,10 @@
 #
 #  Distributed under the MIT License (https://opensource.org/licenses/MIT)
 ###############################################################################
+project(cycfi::json)
 cmake_minimum_required(VERSION 3.7.2)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang"
@@ -29,10 +30,10 @@ add_subdirectory(${INTEGRE_COMMON_ROOT} "${CMAKE_CURRENT_BINARY_DIR}/infra")
 
 cmake_policy(SET CMP0074 NEW)
 
-set(Boost_USE_STATIC_LIBS ON)
+set(Boost_USE_STATIC_LIBS OFF)
 find_package(
   Boost 1.61 REQUIRED
-  COMPONENTS filesystem system)
+  COMPONENTS system)
 
 include_directories(${Boost_INCLUDE_DIRS})
 
@@ -50,7 +51,6 @@ if (DEFINED BOOST_LIBRARYDIR)
    set(BOOST_CMAKE_ARGS ${BOOST_CMAKE_ARGS}
       "-DBOOST_LIBRARYDIR=${BOOST_LIBRARYDIR}")
 endif()
-
 ###############################################################################
 # json
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,14 +30,10 @@ add_subdirectory(${INTEGRE_COMMON_ROOT} "${CMAKE_CURRENT_BINARY_DIR}/infra")
 
 cmake_policy(SET CMP0074 NEW)
 
-set(Boost_USE_STATIC_LIBS OFF)
 find_package(
   Boost 1.61 REQUIRED
-  COMPONENTS system)
-
+  )
 include_directories(${Boost_INCLUDE_DIRS})
-
-add_definitions("-DBOOST_ALL_NO_LIB") # disable auto-linking
 
 set(BOOST_CMAKE_ARGS)
 if (DEFINED BOOST_ROOT)

--- a/include/json/json_io.hpp
+++ b/include/json/json_io.hpp
@@ -7,20 +7,18 @@
 #define JSON_IO_DECEMBER_18_2017
 
 #include <json/json.hpp>
-#include <boost/filesystem.hpp>
-#include <boost/filesystem/fstream.hpp>
-#include <boost/optional.hpp>
+#include <filesystem>
+#include <fstream>
+#include <optional>
 
 namespace cycfi { namespace json
 {
-   namespace fs = boost::filesystem;
-
    template <typename T>
-   boost::optional<T> load(fs::path path)
+   std::optional<T> load(std::filesystem::path path)
    {
-      if (fs::exists(path))
+      if (std::filesystem::exists(path))
       {
-         fs::ifstream file(path);
+         std::ifstream file(path);
          std::string src(
             (std::istreambuf_iterator<char>(file))
          , std::istreambuf_iterator<char>());
@@ -34,9 +32,9 @@ namespace cycfi { namespace json
    }
 
    template <typename T>
-   void save(fs::path path, T const& attr)
+   void save(std::filesystem::path path, T const& attr)
    {
-      fs::ofstream file(path);
+      std::ofstream file(path);
       std::string json;
       printer pr(file);
       pr.print(attr);

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -7,7 +7,10 @@
 #include <infra/doctest.hpp>
 
 #include <json/json.hpp>
+#include <json/json_io.hpp>
+
 #include <boost/fusion/include/equal_to.hpp>
+
 #include <sstream>
 #include <iostream>
 
@@ -244,6 +247,23 @@ TEST_CASE("test_json_struct, test_json")
       // Just for fun!
       // std::cout << ss.str() << std::endl;
    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// test json_io save and load
+TEST_CASE("test_json_io, test_json")
+{
+   std::vector<std::string> c = {"a", "b", "c", "d"};
+
+   std::filesystem::path tmpname(std::tmpnam(nullptr));
+   json::save(tmpname, c);
+   CHECK(std::filesystem::exists(tmpname));
+
+   auto loaded = json::load<std::vector<std::string>>(tmpname);
+   CHECK(loaded);
+   CHECK(same(c, *loaded));
+
+   std::filesystem::remove(tmpname);
 }
 
 


### PR DESCRIPTION
If you want to get an _elements_ app with few dependencies, `<json_io>` drags `<boost/filesystem>` which requires a runtime library and other libraries as transitive dependencies.

Something that you may want to review with care is the added testcase to test `json_io` _load_ and _save_ functionality. My compiler warns me of using `std::tmpnam` because of security, however I don't think there is something else that works in all other platforms. I am open for feedback there.

There is an associated PR to elements too.