### PR TITLE
Add basic C.I. to catch regressions on contributions (PRs)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,34 @@
+name: Build
+on: [push, pull_request]
+env:
+  BUILD_TYPE: Release
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        submodules: 'recursive'
+    - name: Install package dependencies
+      id: cmake_and_ninja
+      run: |
+        sudo apt-get install ninja-build
+    - name: Configure
+      env:
+        CC: "gcc-9"
+        CXX: "g++-9"
+      run: |
+        export BOOST_ROOT=$BOOST_ROOT_1_72_0
+        cmake -S . \
+            -B build \
+            -D CMAKE_BUILD_TYPE=$ENV{BUILD_TYPE} \
+            -G Ninja \
+            -D CMAKE_MAKE_PROGRAM=ninja
+    - name: Build
+      run: |
+        cmake --build build
+    - name: Test
+      working-directory: build
+      run: |
+        ctest .

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ xcuserdata/
 /.vscode/
 /.idea/
 /cmake-build-debug/
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@
 #
 #  Distributed under the MIT License (https://opensource.org/licenses/MIT)
 ###############################################################################
+project(cycfy::json)
 cmake_minimum_required(VERSION 3.7.2)
 
 set(CMAKE_CXX_STANDARD 17)
@@ -20,10 +21,9 @@ endif()
 
 cmake_policy(SET CMP0074 NEW)
 
-set(Boost_USE_STATIC_LIBS ON)
 find_package(
   Boost 1.61 REQUIRED
-  COMPONENTS filesystem system)
+)
 
 include_directories(${Boost_INCLUDE_DIRS})
 
@@ -52,7 +52,9 @@ target_include_directories(
    INTERFACE
       "${CMAKE_CURRENT_SOURCE_DIR}/include"
       "${CMAKE_CURRENT_SOURCE_DIR}/infra/include"
+      "${CMAKE_CURRENT_SOURCE_DIR}/infra/external/filesystem/include"
 )
 
+include(CTest)
 add_subdirectory(test)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 ###############################################################################
 cmake_minimum_required(VERSION 3.7.2)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # Cycfi JSON library
 
+![Build](https://github.com/cycfi/json/workflows/Build/badge.svg)
+
 Strict, type-safe, c++ to JSON I/O library

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,3 +13,4 @@ add_executable(json_test main.cpp)
 
 target_link_libraries(json_test json)
 
+add_test(NAME json_test COMMAND json_test)


### PR DESCRIPTION
A simplified C.I. building and running the tests.

The workflow is much more simple than the one in elements: single platform, not using cmake as a shell across platforms, but calling cmake directly from the standard shell.

Allows for catching test regressions and check build status on Pull Requests.

Already cached errors when building the CI file itself. eg 9f75c5c80b1569be9bc4990c7336ebe738f9573c