### PR TITLE
CMake Install Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,6 @@ xcuserdata/
 /.vscode/
 /.idea/
 /cmake-build-debug/
-build/
+build*/
+*.cmake
+install/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ if (TARGET json)
    return()
 endif()
 
-project(json)
+project(cycfi-json LANGUAGES CXX VERSION 0.1.0)
 
 option(JSON_BUILD_TESTS "build json library tests" ON)
 
@@ -24,26 +24,82 @@ find_package(Boost 1.61 REQUIRED)
 ###############################################################################
 # json
 
-add_subdirectory(infra)
+# add_subdirectory(infra)
 add_library(json INTERFACE)
 
 target_compile_features(json INTERFACE cxx_std_17)
 
-target_include_directories(json INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/include")
+include(GNUInstallDirs)
+target_include_directories(
+   json INTERFACE
+   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/cycfi-json-${PROJECT_VERSION}>
+)
 
 # disable auto-linking
 target_compile_definitions(json INTERFACE BOOST_ALL_NO_LIB)
 
 target_compile_options(json INTERFACE
-   $<$<CXX_COMPILER_ID:GNU>:-ftemplate-backtrace-limit=0>
-   $<$<CXX_COMPILER_ID:Clang>:-ftemplate-backtrace-limit=0>
+   $<BUILD_INTERFACE:
+      $<$<CXX_COMPILER_ID:GNU>:-ftemplate-backtrace-limit=0>
+      $<$<CXX_COMPILER_ID:Clang>:-ftemplate-backtrace-limit=0>
+   >
 )
 
-target_link_libraries(json INTERFACE cycfi::infra Boost::boost)
+target_link_libraries(json INTERFACE Boost::boost)
 
 add_library(cycfi::json ALIAS json)
 
 if (JSON_BUILD_TESTS)
    include(CTest)
+   add_subdirectory(infra)
    add_subdirectory(test)
 endif()
+
+install(
+   TARGETS
+      json
+
+   EXPORT
+     cycfi-json-targets
+
+   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+ )
+
+ install(
+   EXPORT
+     cycfi-json-targets
+
+   NAMESPACE cycfi::
+   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cycfi-json-${PROJECT_VERSION}/
+ )
+
+ install(
+   DIRECTORY
+     include/
+
+   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cycfi-json-${PROJECT_VERSION}/cycfi
+   FILES_MATCHING PATTERN "json.hpp"
+ )
+
+ include(CMakePackageConfigHelpers)
+ write_basic_package_version_file(
+   ${CMAKE_CURRENT_BINARY_DIR}/cycfi-json-config-version.cmake
+   VERSION ${PROJECT_VERSION}
+   COMPATIBILITY AnyNewerVersion
+ )
+
+ configure_package_config_file(
+   ${CMAKE_CURRENT_LIST_DIR}/cmake/cycfi-json-config.cmake.in
+   ${CMAKE_CURRENT_BINARY_DIR}/cycfi-json-config.cmake
+   INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cycfi-json-${PROJECT_VERSION}
+ )
+
+ install(
+   FILES
+     ${CMAKE_CURRENT_BINARY_DIR}/cycfi-json-config.cmake
+     ${CMAKE_CURRENT_BINARY_DIR}/cycfi-json-config-version.cmake
+   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cycfi-json-${PROJECT_VERSION}
+ )

--- a/cmake/cycfi-json-config.cmake.in
+++ b/cmake/cycfi-json-config.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+find_dependency(Boost 1.61 REQUIRED)
+include(${CMAKE_CURRENT_LIST_DIR}/cycfi-json-targets.cmake)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,6 +12,6 @@ project(json_test)
 add_executable(json_test)
 target_sources(json_test PRIVATE main.cpp)
 
-target_link_libraries(json_test PRIVATE cycfi::json)
+target_link_libraries(json_test PRIVATE cycfi::infra cycfi::json)
 
 add_test(NAME json_test COMMAND json_test)


### PR DESCRIPTION
This PR gives the core lib the ability to be installed via CMake and then consumed via `find_package`.

I'm not 100% on things like the name of the exported package and I also noted that we can't link directly to the infra target as that would also need to be installable so I have the testing binary link to it directly to support this.

Note, this also means that we can't install the IO header as well.

Possible paths forward would be: make infra installable or just keep this as is.